### PR TITLE
part6: calc6.py -> edit LPARENT condition in factor method of Interpreter class

### DIFF
--- a/part6/calc6.py
+++ b/part6/calc6.py
@@ -129,7 +129,7 @@ class Interpreter(object):
         if token.type == INTEGER:
             self.eat(INTEGER)
             return token.value
-        elif token.type == LPAREN:
+        else:
             self.eat(LPAREN)
             result = self.expr()
             self.eat(RPAREN)


### PR DESCRIPTION
Hi dear friend
If the desired condition checks the LPARENT type in the following example
5+) 3)
Instead of Invalid syntax error, it encounters this error

Traceback (most recent call last):
  File "c: /Users/Dell/Desktop/interpreter/interpreter.py", line 194, in <module>
    main ()
  File "c: /Users/Dell/Desktop/interpreter/interpreter.py", line 189, in main
    result = interpreter.expr ()
  File "c: /Users/Dell/Desktop/interpreter/interpreter.py", line 169, in expr
    result = result + self.term ()
TypeError: unsupported operand type (s) for +: 'int' and 'NoneType'